### PR TITLE
Add specificity to css selectors

### DIFF
--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -4,6 +4,7 @@ import hashStr from '../vendor/glamor/hash'
 import type { RuleSet, NameGenerator, Flattener, Stringifier } from '../types'
 import StyleSheet from './StyleSheet'
 import isStyledComponent from '../utils/isStyledComponent'
+import getComponentCssSelector from '../utils/getComponentCssSelector'
 
 const isStaticRules = (rules: RuleSet): boolean => {
   for (let i = 0; i < rules.length; i += 1) {
@@ -33,7 +34,6 @@ export default (nameGenerator: NameGenerator, flatten: Flattener, stringifyRules
     isStatic: boolean
     lastClassName: ?string
 
-
     constructor(rules: RuleSet, componentId: string) {
       this.rules = rules
       this.isStatic = isStaticRules(rules)
@@ -49,7 +49,11 @@ export default (nameGenerator: NameGenerator, flatten: Flattener, stringifyRules
      * Hashes it, wraps the whole chunk in a .hash1234 {}
      * Returns the hash to be injected on render()
      * */
-    generateAndInjectStyles(executionContext: Object, styleSheet: StyleSheet) {
+    generateAndInjectStyles(
+      executionContext: Object,
+      styleSheet: StyleSheet,
+      options: Object = {},
+    ) {
       const { isStatic, lastClassName } = this
       if (isStatic && lastClassName !== undefined) {
         return lastClassName
@@ -74,7 +78,9 @@ export default (nameGenerator: NameGenerator, flatten: Flattener, stringifyRules
         return name
       }
 
-      const css = `\n${stringifyRules(flatCSS, `.${name}`)}`
+      const selector = getComponentCssSelector(name, options)
+
+      const css = `\n${stringifyRules(flatCSS, selector)}`
       // NOTE: this can only be set when we inject the class-name.
       // For some reason, presumably due to how css is stringifyRules behaves in
       // differently between client and server, styles break.

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -31,7 +31,7 @@ export default class StyleSheet {
   deferredInjections: { [string]: string } = {}
   componentTags: { [string]: Tag }
   // helper for `ComponentStyle` to know when it cache static styles.
-  // staticly styled-component can not safely cache styles on the server
+  // statically styled-component can not safely cache styles on the server
   // without all `ComponentStyle` instances saving a reference to the
   // the styleSheet instance they last rendered with,
   // or listening to creation / reset events. otherwise you might create

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -28,161 +28,167 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
   /* We depend on components having unique IDs */
   const identifiers = {}
   const generateId = (_displayName: string, parentComponentId: string) => {
-    const displayName = typeof _displayName !== 'string' ?
-      'sc' : _displayName
-        .replace(escapeRegex, '-') // Replace all possible CSS selectors
-        .replace(multiDashRegex, '-') // Replace multiple -- with single -
+    const displayName =
+      typeof _displayName !== 'string'
+        ? 'sc'
+        : _displayName
+          .replace(escapeRegex, '-') // Replace all possible CSS selectors
+          .replace(multiDashRegex, '-') // Replace multiple -- with single -
 
     const nr = (identifiers[displayName] || 0) + 1
     identifiers[displayName] = nr
 
     const hash = ComponentStyle.generateName(displayName + nr)
     const componentId = `${displayName}-${hash}`
-    return parentComponentId !== undefined
-      ? `${parentComponentId}-${componentId}`
-      : componentId
+    return parentComponentId !== undefined ? `${parentComponentId}-${componentId}` : componentId
   }
 
-  class BaseStyledComponent extends Component {
-    static target: Target
-    static styledComponentId: string
-    static attrs: Object
-    static componentStyle: Object
-    static warnTooManyClasses: Function
+  const createBaseStyledComponent = (options: Object) => {
+    class BaseStyledComponent extends Component {
+      static target: Target
+      static styledComponentId: string
+      static attrs: Object
+      static componentStyle: Object
+      static warnTooManyClasses: Function
 
-    attrs = {}
-    state = {
-      theme: null,
-      generatedClassName: '',
-    }
-    unsubscribeId: number = -1
-
-    unsubscribeFromContext() {
-      if (this.unsubscribeId !== -1) {
-        this.context[CHANNEL_NEXT].unsubscribe(this.unsubscribeId)
+      attrs = {}
+      state = {
+        theme: null,
+        generatedClassName: '',
       }
-    }
+      unsubscribeId: number = -1
 
-    buildExecutionContext(theme: any, props: any) {
-      const { attrs } = this.constructor
-      const context = { ...props, theme }
-      if (attrs === undefined) {
-        return context
+      unsubscribeFromContext() {
+        if (this.unsubscribeId !== -1) {
+          this.context[CHANNEL_NEXT].unsubscribe(this.unsubscribeId)
+        }
       }
 
-      this.attrs = Object.keys(attrs).reduce((acc, key) => {
-        const attr = attrs[key]
-        // eslint-disable-next-line no-param-reassign
-        acc[key] = typeof attr === 'function' ? attr(context) : attr
-        return acc
-      }, {})
+      buildExecutionContext(theme: any, props: any) {
+        const { attrs } = this.constructor
+        const context = { ...props, theme }
+        if (attrs === undefined) {
+          return context
+        }
 
-      return { ...context, ...this.attrs }
-    }
+        this.attrs = Object.keys(attrs).reduce((acc, key) => {
+          const attr = attrs[key]
+          // eslint-disable-next-line no-param-reassign
+          acc[key] = typeof attr === 'function' ? attr(context) : attr
+          return acc
+        }, {})
 
-    generateAndInjectStyles(theme: any, props: any) {
-      const { attrs, componentStyle, warnTooManyClasses } = this.constructor
-      const styleSheet = this.context[CONTEXT_KEY] || StyleSheet.instance
-
-      // staticaly styled-components don't need to build an execution context object,
-      // and shouldn't be increasing the number of class names
-      if (componentStyle.isStatic && attrs === undefined) {
-        return componentStyle.generateAndInjectStyles(STATIC_EXECUTION_CONTEXT, styleSheet)
-      } else {
-        const executionContext = this.buildExecutionContext(theme, props)
-        const className = componentStyle.generateAndInjectStyles(executionContext, styleSheet)
-
-        if (warnTooManyClasses !== undefined) warnTooManyClasses(className)
-
-        return className
+        return { ...context, ...this.attrs }
       }
-    }
 
-    componentWillMount() {
-      const { componentStyle } = this.constructor
-      const styledContext = this.context[CHANNEL_NEXT]
+      generateAndInjectStyles(theme: any, props: any) {
+        const { attrs, componentStyle, warnTooManyClasses } = this.constructor
+        const styleSheet = this.context[CONTEXT_KEY] || StyleSheet.instance
 
-      // If this is a staticaly-styled component, we don't need to the theme
-      // to generate or build styles.
-      if (componentStyle.isStatic) {
-        const generatedClassName = this.generateAndInjectStyles(
-          STATIC_EXECUTION_CONTEXT,
-          this.props,
-        )
-        this.setState({ generatedClassName })
-      // If there is a theme in the context, subscribe to the event emitter. This
-      // is necessary due to pure components blocking context updates, this circumvents
-      // that by updating when an event is emitted
-      } else if (styledContext !== undefined) {
-        const { subscribe } = styledContext
-        this.unsubscribeId = subscribe(nextTheme => {
-          // This will be called once immediately
-          const theme = determineTheme(this.props, nextTheme, this.constructor.defaultProps)
+        // statically styled-components don't need to build an execution context object,
+        // and shouldn't be increasing the number of class names
+        if (componentStyle.isStatic && attrs === undefined) {
+          return componentStyle.generateAndInjectStyles(
+            STATIC_EXECUTION_CONTEXT,
+            styleSheet,
+            options,
+          )
+        } else {
+          const executionContext = this.buildExecutionContext(theme, props)
+          const className = componentStyle.generateAndInjectStyles(
+            executionContext,
+            styleSheet,
+            options,
+          )
+
+          if (warnTooManyClasses !== undefined) warnTooManyClasses(className)
+
+          return className
+        }
+      }
+
+      componentWillMount() {
+        const { componentStyle } = this.constructor
+        const styledContext = this.context[CHANNEL_NEXT]
+
+        // If this is a statically-styled component, we don't need to the theme
+        // to generate or build styles.
+        if (componentStyle.isStatic) {
+          const generatedClassName = this.generateAndInjectStyles(
+            STATIC_EXECUTION_CONTEXT,
+            this.props,
+          )
+          this.setState({ generatedClassName })
+          // If there is a theme in the context, subscribe to the event emitter. This
+          // is necessary due to pure components blocking context updates, this circumvents
+          // that by updating when an event is emitted
+        } else if (styledContext !== undefined) {
+          const { subscribe } = styledContext
+          this.unsubscribeId = subscribe(nextTheme => {
+            // This will be called once immediately
+            const theme = determineTheme(this.props, nextTheme, this.constructor.defaultProps)
+            const generatedClassName = this.generateAndInjectStyles(theme, this.props)
+
+            this.setState({ theme, generatedClassName })
+          })
+        } else {
+          // eslint-disable-next-line react/prop-types
+          const theme = this.props.theme || {}
           const generatedClassName = this.generateAndInjectStyles(theme, this.props)
-
           this.setState({ theme, generatedClassName })
+        }
+      }
+
+      componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
+        // If this is a statically-styled component, we don't need to listen to
+        // props changes to update styles
+        const { componentStyle } = this.constructor
+        if (componentStyle.isStatic) {
+          return
+        }
+
+        this.setState(oldState => {
+          const theme = determineTheme(nextProps, oldState.theme, this.constructor.defaultProps)
+          const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
+
+          return { theme, generatedClassName }
         })
-      } else {
+      }
+
+      componentWillUnmount() {
+        this.unsubscribeFromContext()
+      }
+
+      render() {
         // eslint-disable-next-line react/prop-types
-        const theme = this.props.theme || {}
-        const generatedClassName = this.generateAndInjectStyles(
-          theme,
-          this.props,
-        )
-        this.setState({ theme, generatedClassName })
-      }
-    }
+        const { innerRef } = this.props
+        const { generatedClassName } = this.state
+        const { styledComponentId, target } = this.constructor
 
-    componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
-      // If this is a staticaly-styled component, we don't need to listen to
-      // props changes to update styles
-      const { componentStyle } = this.constructor
-      if (componentStyle.isStatic) {
-        return
-      }
+        const isTargetTag = isTag(target)
 
-      this.setState((oldState) => {
-        const theme = determineTheme(nextProps, oldState.theme, this.constructor.defaultProps)
-        const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
+        const className = [
+          // eslint-disable-next-line react/prop-types
+          this.props.className,
+          styledComponentId,
+          this.attrs.className,
+          generatedClassName,
+        ]
+          .filter(Boolean)
+          .join(' ')
 
-        return { theme, generatedClassName }
-      })
-    }
+        const baseProps = {
+          ...this.attrs,
+          className,
+        }
 
-    componentWillUnmount() {
-      this.unsubscribeFromContext()
-    }
+        if (isStyledComponent(target)) {
+          baseProps.innerRef = innerRef
+        } else {
+          baseProps.ref = innerRef
+        }
 
-    render() {
-      // eslint-disable-next-line react/prop-types
-      const { innerRef } = this.props
-      const { generatedClassName } = this.state
-      const { styledComponentId, target } = this.constructor
-
-      const isTargetTag = isTag(target)
-
-      const className = [
-        // eslint-disable-next-line react/prop-types
-        this.props.className,
-        styledComponentId,
-        this.attrs.className,
-        generatedClassName,
-      ].filter(Boolean).join(' ')
-
-      const baseProps = {
-        ...this.attrs,
-        className,
-      }
-
-      if (isStyledComponent(target)) {
-        baseProps.innerRef = innerRef
-      } else {
-        baseProps.ref = innerRef
-      }
-
-      const propsForElement = Object
-        .keys(this.props)
-        .reduce((acc, propName) => {
+        const propsForElement = Object.keys(this.props).reduce((acc, propName) => {
           // Don't pass through non HTML tags through to HTML elements
           // always omit innerRef
           if (
@@ -197,25 +203,26 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
           return acc
         }, baseProps)
 
-      return createElement(target, propsForElement)
+        return createElement(target, propsForElement)
+      }
     }
+
+    return BaseStyledComponent
   }
 
-  const createStyledComponent = (
-    target: Target,
-    options: Object,
-    rules: RuleSet,
-  ) => {
+  const createStyledComponent = (target: Target, options: Object, rules: RuleSet) => {
     const {
       displayName = isTag(target) ? `styled.${target}` : `Styled(${getComponentName(target)})`,
       componentId = generateId(options.displayName, options.parentComponentId),
-      ParentComponent = BaseStyledComponent,
+      ParentComponent = createBaseStyledComponent(options),
       rules: extendingRules,
       attrs,
     } = options
 
-    const styledComponentId = (options.displayName && options.componentId) ?
-      `${options.displayName}-${options.componentId}` : componentId
+    const styledComponentId =
+      options.displayName && options.componentId
+        ? `${options.displayName}-${options.componentId}`
+        : componentId
 
     let warnTooManyClasses
     if (process.env.NODE_ENV !== 'production') {
@@ -267,10 +274,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
           ...optionsToCopy
         } = options
 
-        const newRules =
-          rulesFromOptions === undefined
-            ? rules
-            : rulesFromOptions.concat(rules)
+        const newRules = rulesFromOptions === undefined ? rules : rulesFromOptions.concat(rules)
 
         const newOptions = {
           ...optionsToCopy,

--- a/src/utils/getComponentCssSelector.js
+++ b/src/utils/getComponentCssSelector.js
@@ -1,0 +1,12 @@
+// @flow
+
+/**
+ * Adjusts the css selector for the component's css to increase specificity when needed
+ */
+export default function getComponentCssSelector(componentName: string, options: Object) {
+  if (options && options.specificityClass) {
+    return `.${options.specificityClass} .${componentName}`
+  }
+
+  return `.${componentName}`
+}

--- a/src/utils/test/getComponentCssSelector.test.js
+++ b/src/utils/test/getComponentCssSelector.test.js
@@ -1,0 +1,23 @@
+// @flow
+import getComponentCssSelector from '../getComponentCssSelector'
+
+describe('getComponentCssSelector', () => {
+  const testComponentName = 'testComponent'
+  const testSpecificityClass = 'moreSpecific'
+
+  it('returns the name as selector if options are not provided', () => {
+    expect(getComponentCssSelector(testComponentName)).toEqual(`.${testComponentName}`)
+  })
+
+  it('returns the name if the specificity class is not defined on options', () => {
+    expect(getComponentCssSelector(testComponentName, { displayName: 'test' })).toEqual(
+      `.${testComponentName}`,
+    )
+  })
+
+  it('returns the name prepended with the specificity class', () => {
+    expect(
+      getComponentCssSelector(testComponentName, { specificityClass: testSpecificityClass }),
+    ).toEqual(`.${testSpecificityClass} .${testComponentName}`)
+  })
+})


### PR DESCRIPTION
Allows the specificity of the css selector for a styled component to be modified through the options.

It passes through the options to the BaseStyledComponent so that it can call the css `generateAndInjectStyles` with the options. The specificityClass is set in options and used to increase the specificity of all classes.

This works with https://github.com/QuickBase/babel-plugin-styled-components/pull/1 to apply the options through babel.